### PR TITLE
Build & test against JDK 8, also test against JDK 11 and 15

### DIFF
--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=java-library-oss
+export JDK=8
+export UNIT_TEST_11=true
+export UNIT_TEST_15=true


### PR DESCRIPTION
Setup circle template to build & test against JDK 8, also test against JDK 11 and 15 to ensure coverage and excavators don't remove those tests (see https://github.com/palantir/jvm-diagnostics/pull/2 and https://github.com/palantir/jvm-diagnostics/pull/4 )