### PR TITLE
Add `Add-Exports: java.management/sun.management` to the jar manifest

### DIFF
--- a/changelog/@unreleased/pr-62.v2.yml
+++ b/changelog/@unreleased/pr-62.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Add `Add-Exports: java.management/sun.management` to the jar manifest'
+  links:
+  - https://github.com/palantir/jvm-diagnostics/pull/62

--- a/jvm-diagnostics/build.gradle
+++ b/jvm-diagnostics/build.gradle
@@ -7,3 +7,11 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'
 }
+
+// This block may be replaced by BaselineExportsExtension exports
+// once https://github.com/gradle/gradle/issues/18824 is resolved.
+jar {
+  manifest {
+    attributes('Add-Exports': 'java.management/sun.management')
+  }
+}


### PR DESCRIPTION
See https://github.com/palantir/gradle-baseline/pull/1944
This will allow other plugins to apply the export to jvm args
without special casing this library or `java.management` specifically.