### PR TITLE
Library targets JDK 11 bytecode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.palantir.consistent-versions'
 apply plugin: 'com.palantir.baseline-java-versions'
 
 javaVersions {
-    libraryTarget = 8
+    libraryTarget = 11
     runtime = 17
 }
 

--- a/changelog/@unreleased/pr-105.v2.yml
+++ b/changelog/@unreleased/pr-105.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Library targets JDK 11 bytecode
+  links:
+  - https://github.com/palantir/jvm-diagnostics/pull/105


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Library targeted JDK 8 bytecode

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Library targets JDK 11 bytecode
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Blocked by https://github.com/gradle/gradle/issues/18824 for now as we can't `--add-exports=java.management/sun.management` with gradle toolchains, see https://github.com/palantir/jvm-diagnostics/pull/96#issuecomment-1023588766
