### PR TITLE
Update SafepointTimeAccessor to add method for time getting to safepoints

### DIFF
--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/JvmDiagnostics.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/JvmDiagnostics.java
@@ -149,6 +149,11 @@ public final class JvmDiagnostics {
         public long safepointTimeMilliseconds() {
             return hotspotRuntimeManagementBean.getTotalSafepointTime();
         }
+
+        @Override
+        public long safepointSyncTimeMilliseconds() {
+            return hotspotRuntimeManagementBean.getSafepointSyncTime();
+        }
     }
 
     private static final class HotspotThreadAllocatedBytesAccessor implements ThreadAllocatedBytesAccessor {

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/SafepointTimeAccessor.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/SafepointTimeAccessor.java
@@ -20,4 +20,7 @@ public interface SafepointTimeAccessor {
 
     /** Gets the total time spent at safepoints since the JVM was started, in milliseconds. */
     long safepointTimeMilliseconds();
+
+    /** Gets the total time spent getting to safepoints since the JVM was started, in milliseconds. */
+    long safepointSyncTimeMilliseconds();
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, we only exposed the time spent **_at_** a safepoint, which would indicate the runtime spending a lot of time performing the work at a particular safepoint vm op. However, we didn't report to amount of time threads spent **_getting to_** a safepoint, which could also be an indication of performance issues resulting from calls to native code, excessively long counted loops, or other things which can prevent quickly reaching a safepoint.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update SafepointTimeAccessor to add method for time getting to safepoints
==COMMIT_MSG==

The eventual goal is to expose this through tritium as a metric in the SafepointMetrics:
```java
InternalJvmMetrics.of(registry).safepointSyncTime(safepointTimeAccessor.get()::safepointSyncTimeMilliseconds);
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

