### PR TITLE
Add Linux Pressure Stall Information (PSI) metrics support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 # Gradle JDKs setup
 !gradle/*
+
+.claude
+.jqwik-database

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,495 @@
+# CLAUDE.md - Java Project Guidance
+
+## Common Commands
+
+### Build and Test
+
+- `./gradlew build` - Build the entire project
+- `./gradlew check` - Run all checks (includes tests, javadoc, checkUnusedDependencies)
+- `./gradlew :jvm-diagnostics:test` - Run tests for the jvm-diagnostics module only
+- `./gradlew :jvm-diagnostics:check` - Run all checks for the jvm-diagnostics module only
+- `./gradlew test --tests "com.palantir.jvm.diagnostics.JvmDiagnosticsTest.BasicDiagnosticsTest.testSafepointTime"` - Run a single test method
+
+### Code Formatting
+
+- `./gradlew format` - Format code according to Palantir Java Format standards
+- `./gradlew formatDiff` - Format only chunks that appear in git diff
+- `./gradlew spotlessCheck` - Check formatting without making changes
+- `./gradlew spotlessApply` - Apply formatting fixes
+
+### Dependency Management
+
+- `./gradlew --write-locks` - Regenerate versions.lock after changing versions.props
+- `./gradlew verifyLocks` - Verify that versions.lock is up to date
+- `./gradlew checkUnusedDependencies` - Check for unused dependencies
+- `./gradlew checkImplicitDependenciesMain` - Ensure all dependencies are explicitly declared
+
+Prefer `./gradlew --quiet` for reduced output verbosity.
+
+## Code Architecture
+
+This is a Gradle-based Java library project (`com.palantir.gt`) with a single module:
+
+- **`jvm-diagnostics/`** - Core module containing all source code under `com.palantir.gt` package
+
+### Build Configuration
+
+- **Java compiler**: 25, **Library target**: 17, **Runtime**: 25, **Daemon target**: 21
+- Compilation uses `-Werror` (warnings are errors)
+- Uses [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions): versions defined in `versions.props`, locked in `versions.lock`
+
+### Key Patterns
+
+- **Immutables**: The `Foo` interface uses `@Value.Immutable` to generate `ImmutableFoo` with builders, hashCode, and toString. The annotation processor runs at compile time.
+- **Safe Logging**: Uses Palantir's `SafeLogger` with `SafeArg`/`UnsafeArg` for log safety. The `strict-log-safety` plugin enforces correct usage at compile time.
+- **Error Prone + NullAway**: Static analysis runs during compilation to catch common bugs and null safety issues.
+
+### Testing
+
+- JUnit Jupiter + AssertJ
+- Tests live in `jvm-diagnostics/src/test/java/`
+
+## Development Guidelines
+
+### Git and Pull Requests
+
+- PR descriptions must follow `.github/PULL_REQUEST_TEMPLATE.md` with sections: Before this PR, After this PR, Testing, Possible downsides?, Are Docs needed?
+- NEVER write to external systems (PUT/DELETE/POST) without explicit confirmation
+
+
+> Derived from [Palantir Baseline Best Practices](https://github.com/palantir/gradle-baseline/tree/develop/docs) and seasoned engineering judgment. This document is the canonical reference for AI agents and human engineers working in this codebase.
+
+---
+
+## 0. Foundational Mindset
+
+**Chesterton's Fence.** Do not change code, patterns, or configurations until you understand *why* they exist. If you cannot articulate the original rationale, investigate before modifying.
+
+**Bias toward boring.** Prefer well-understood, widely-adopted solutions over clever ones. Cleverness is a liability in production; clarity is an asset.
+
+---
+
+## 1. Class & Module Design
+
+### Single Responsibility Principle (SRP)
+
+Every class must have **one reason to change**. If you cannot describe a class's purpose in a single sentence without the word "and", it is doing too much. Split it.
+
+- A class that parses input **and** validates it **and** persists it has three responsibilities. Factor into `InputParser`, `InputValidator`, and `InputRepository`.
+- SRP applies at every level: methods do one thing, classes own one concept, packages represent one bounded context, modules encapsulate one deployable capability.
+- When in doubt, prefer **more, smaller classes** over fewer, larger ones. Small classes are easier to name, test, review, and replace.
+
+### Cohesion & Coupling
+
+- **High cohesion:** every field and method in a class should relate to its single responsibility. If a subset of fields is only used by a subset of methods, that's a new class waiting to be extracted.
+- **Low coupling:** depend on abstractions, not concretions. Accept interfaces in constructors and method parameters. Return concrete types only when the caller genuinely needs them.
+- Prefer composition over inheritance. Inheritance creates tight coupling between parent and child; composition allows substitution and independent evolution.
+
+### Interface Segregation
+
+- Do not force clients to depend on methods they don't use. Prefer several small, focused interfaces over one large one.
+- A `ReadableRepository` and a `WritableRepository` are better than a `Repository` with 20 methods, half of which throw `UnsupportedOperationException` in read-only implementations.
+
+### Dependency Inversion
+
+- High-level policy classes must not depend on low-level infrastructure classes. Both should depend on interfaces defined at the policy level.
+- Constructor injection is the default. Avoid field injection (`@Inject` on fields) - it hides dependencies and defeats immutability.
+
+### Package & Module Organization
+
+- Organize packages by **feature/domain**, not by layer. `com.acme.orders` containing `Order`, `OrderService`, `OrderRepository` is better than `com.acme.model`, `com.acme.service`, `com.acme.repository` each containing fragments of every feature.
+- A package's public API should be minimal. Use package-private visibility aggressively - only make classes and methods `public` when they are genuinely part of the module's contract.
+
+---
+
+## 2. Immutability & State
+
+- **Make every field `final` whenever possible.** Make every class immutable where possible.
+- When returning collection-typed fields, return an `ImmutableList`, `ImmutableSet`, `ImmutableMap`, or an unmodifiable view. Never leak mutable internal state.
+- Fields must be `private` unless they are `static final` and immutable, or annotated `@VisibleForTesting` / `@Rule`.
+- **Never use mutable static fields.** Static state couples code to external factors, defeats testability, and makes correctness proofs impossible.
+- Avoid `static` methods unless they are trivial, fast, and dependency-free.
+- Exception classes are always immutable.
+
+```java
+// GOOD: Immutable value object - single responsibility: represent a coordinate
+public final class Coordinate {
+    private final double lat;
+    private final double lon;
+
+    public Coordinate(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
+
+    public double lat() { return lat; }
+    public double lon() { return lon; }
+}
+```
+
+---
+
+## 3. Object Construction & Initialization
+
+- Objects must be fully constructed via their constructor. **No `initialize()` or `setup()` post-construction methods.** If complex initialization is required, use the Factory pattern with appropriate visibility scoping.
+- Constructors may allocate new value objects (e.g., `new ArrayList<>()`), but must not perform I/O, start threads, or register callbacks.
+- **Use the Builder pattern** when a class has many optional fields or more than ~4 constructor parameters. Builders should accept all required fields as constructor parameters, expose setters for optional fields that return `this`, and provide a `build()` method.
+- Declare a class `final` if all of its constructors are `private`.
+- Utility classes (all static members) must have a `private` zero-arg constructor.
+
+---
+
+## 4. Libraries & Dependencies
+
+- **Use existing libraries.** Someone has probably written this before.
+- Prefer **Guava** over Apache Commons. Prefer Apache Commons over reimplementing from scratch.
+- Apache Commons Lang 2.x is deprecated; use version 3.x.
+- Prefer JDK standard library constructors over Guava factory methods where equivalent: `new ArrayList<>()` over `Lists.newArrayList()`, `new HashMap<>()` over `Maps.newHashMap()`.
+- Use `java.util.Optional` (not `com.google.common.base.Optional`) and `java.util.function.Supplier` (not Guava's).
+- If a library *almost* does what you need, submit a patch upstream rather than forking or wrapping.
+- Read and know the APIs of standard libraries (Guava, JDK collections, `java.util.stream`, `java.time`).
+
+---
+
+## 5. Concurrency
+
+- **Learn and use `java.util.concurrent`.** Use `Executors`, `Future`, `CompletableFuture`, `ExecutorService`, `ConcurrentHashMap`, and the `java.util.concurrent.atomic` package.
+- **Do not use** raw `Thread`, `ThreadGroup`, `synchronized`, `wait`, `notify`, or `notifyAll` unless you can formally prove correctness by referencing the JVM specification-and even then, don't.
+- **Do not use Java parallel streams** (`Collection.parallelStream()`). They use the common `ForkJoinPool`, which creates unpredictable thread contention with the rest of the application.
+- Write the simplest possible synchronization scheme. Concurrency bugs are transient and nearly impossible to reproduce. Simple code is the only reliable defense.
+- Required reading: *Java Concurrency in Practice* by Brian Goetz.
+
+---
+
+## 6. Error Handling & Exceptions
+
+- Use standard log levels consistently: **Fatal** (app cannot continue; page an admin), **Error** (problem occurred but app continues; must be actionable), **Warn** (something unexpected; monitor), **Debug/Trace** (development diagnostics).
+- Do not nest `try/catch` blocks-they obfuscate control flow. Restructure into separate methods.
+- Be consistent in how methods signal failure. Within the same class, do not mix returning `null`, throwing exceptions, returning empty collections, and returning `Optional.empty()` for the same category of failure.
+- Return empty collections rather than `null` when there are no values.
+- Use `Optional` for return types when absence is a normal, expected case-not for fields, parameters, or collections.
+
+---
+
+## 7. Logging
+
+- **Use SLF4J exclusively.** Do not import `java.util.logging`, Log4j, Log4j2, or Logback directly.
+- Log messages must be compile-time constants (enforced by `Slf4jConstantLogMessage` check). Parameterize with `{}` placeholders; never concatenate strings in log statements.
+- Use safe-logging (`com.palantir.logsafe`) for any arguments that may contain sensitive data. Distinguish between `SafeArg` and `UnsafeArg`.
+
+```java
+// GOOD
+log.info("Processed request", SafeArg.of("requestId", id), UnsafeArg.of("userId", userId));
+
+// BAD - string concatenation, not safe-logging aware
+log.info("Processed request " + id + " for user " + userId);
+```
+
+---
+
+## 8. API & Method Design
+
+- Each method should do **one thing** (SRP at the method level). If a method name requires "and" - split it.
+- Do not overload methods more than once or twice. Excessive overloading confuses callers.
+- When a method has many optional arguments, extract it into a function object with the Builder pattern and a `run()` method.
+- Avoid ternary operators where they make code hard to follow. Prefer explicit `if/else` for non-trivial conditions.
+- Override `Object.equals()` consistently-never define a covariant `equals(MyType other)` without also overriding `equals(Object)`.
+- Never instantiate primitive wrapper types directly (`new Boolean(true)`). Use `Boolean.valueOf()` or autoboxing.
+- **Design APIs that are hard to misuse.** Prefer types over stringly-typed parameters. An `EmailAddress` value object is better than a `String email` parameter.
+
+---
+
+## 9. Code Style & Formatting
+
+- **Automate formatting.** Use `palantir-java-format` (or the project's configured formatter) via `./gradlew format`. Never debate style in code reviews; let tooling settle it.
+- Line length: 120 characters for code, 80 characters for chained method calls.
+- Use `com.palantir.baseline` Checkstyle rules as the style baseline. Style violations must not reach code review.
+- Commit messages follow the imperative form: `"Fix bug"` not `"Fixed bug"` or `"Fixes bug"`. Capitalize the summary, keep it under 80 characters, wrap body at ~120.
+
+---
+
+## 10. Testing
+
+### Philosophy
+
+Testing is not a phase - it is a design tool. If code is hard to test, it is poorly designed. Difficulty writing a unit test is a signal to refactor: extract a dependency, split a class, simplify a method.
+
+### Unit Tests
+
+- Every public method should have corresponding unit tests. Tests run fast, are isolated, and are deterministic.
+- Use **JUnit 5** (`org.junit.jupiter`) as the default test framework. Use **AssertJ** for fluent assertions.
+- Structure tests as **Arrange / Act / Assert**. One logical assertion per test method.
+- Test class naming: `<ClassUnderTest>Test.java`.
+
+### Positive & Negative Test Cases
+
+Every unit of behavior requires **both** happy-path and failure-path coverage. Skipping negative cases is the #1 source of production surprises.
+
+**Positive tests** verify that the system behaves correctly given valid input and normal conditions:
+
+```java
+@Test
+void parsesValidCoordinate() {
+    Coordinate coord = CoordinateParser.parse("51.5074,-0.1278");
+    assertThat(coord.lat()).isCloseTo(51.5074, within(1e-4));
+    assertThat(coord.lon()).isCloseTo(-0.1278, within(1e-4));
+}
+```
+
+**Negative tests** verify that the system fails correctly given invalid input, boundary conditions, and adversarial scenarios:
+
+```java
+@Test
+void rejectsNullInput() {
+    assertThatThrownBy(() -> CoordinateParser.parse(null))
+        .isInstanceOf(NullPointerException.class);
+}
+
+@Test
+void rejectsMalformedInput() {
+    assertThatThrownBy(() -> CoordinateParser.parse("not-a-coord"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid coordinate format");
+}
+
+@Test
+void rejectsOutOfRangeLatitude() {
+    assertThatThrownBy(() -> CoordinateParser.parse("91.0,0.0"))
+        .isInstanceOf(IllegalArgumentException.class);
+}
+```
+
+**Negative test case checklist:**
+
+| Category | Examples |
+|---|---|
+| Null / missing inputs | `null`, empty string, empty collection |
+| Boundary values | `Integer.MAX_VALUE`, `0`, `-1`, off-by-one |
+| Malformed data | Invalid format, wrong types, truncated input |
+| Constraint violations | Out-of-range values, duplicate keys, oversized payloads |
+| Concurrency hazards | Concurrent modification, timeout, interruption |
+| Resource failures | Unavailable service, full disk, permission denied |
+| Security edge cases | Injection strings, overlong inputs, unicode edge cases |
+
+### Property-Based Testing with jqwik
+
+Example-based tests verify specific cases you thought of. **Property-based tests** verify invariants across thousands of cases you didn't think of. Use [jqwik](https://jqwik.net/) for property-based testing wherever the domain has clear invariants.
+
+**When to use property-based tests:**
+- Serialization round-trips: `deserialize(serialize(x)) == x`
+- Codec/parser symmetry: `decode(encode(x)) == x`
+- Algebraic properties: commutativity, associativity, idempotency
+- Invariant preservation: "after any sequence of operations, the data structure's invariants still hold"
+- Domain constraint enforcement: "no matter what valid input, the output satisfies these constraints"
+- Comparison with a reference implementation: "optimized path produces same results as naive path"
+
+**Dependency:**
+```groovy
+testImplementation 'net.jqwik:jqwik:1.9.+'
+```
+
+**Example - round-trip serialization property:**
+
+```java
+import net.jqwik.api.*;
+
+class CoordinateSerializationProperties {
+
+    @Property
+    void roundTripPreservesCoordinate(@ForAll("validCoordinates") Coordinate original) {
+        String serialized = CoordinateSerializer.serialize(original);
+        Coordinate deserialized = CoordinateSerializer.deserialize(serialized);
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    @Provide
+    Arbitrary<Coordinate> validCoordinates() {
+        Arbitrary<Double> lats = Arbitraries.doubles().between(-90.0, 90.0);
+        Arbitrary<Double> lons = Arbitraries.doubles().between(-180.0, 180.0);
+        return Combinators.combine(lats, lons).as(Coordinate::new);
+    }
+}
+```
+
+**Example - invariant preservation property:**
+
+```java
+class SortedSetProperties {
+
+    @Property
+    void elementsAlwaysSorted(@ForAll List<@IntRange(min = -1000, max = 1000) Integer> elements) {
+        SortedSet<Integer> set = new TreeSet<>(elements);
+        List<Integer> asList = new ArrayList<>(set);
+
+        for (int i = 1; i < asList.size(); i++) {
+            assertThat(asList.get(i)).isGreaterThan(asList.get(i - 1));
+        }
+    }
+
+    @Property
+    void sizeNeverExceedsInputSize(@ForAll List<Integer> elements) {
+        SortedSet<Integer> set = new TreeSet<>(elements);
+        assertThat(set.size()).isLessThanOrEqualTo(elements.size());
+    }
+}
+```
+
+**Example - idempotency property:**
+
+```java
+class NormalizerProperties {
+
+    @Property
+    void normalizationIsIdempotent(@ForAll @StringLength(max = 500) String raw) {
+        String once = Normalizer.normalize(raw);
+        String twice = Normalizer.normalize(once);
+        assertThat(twice).isEqualTo(once);
+    }
+}
+```
+
+**jqwik guidelines:**
+- Annotate property test methods with `@Property`, not `@Test`.
+- Use `@Provide` methods to define domain-specific `Arbitrary` generators that respect real business constraints. Generic random data is less useful than constrained domain data.
+- Set `@Property(tries = 1000)` for fast properties; increase for subtle invariants.
+- When jqwik finds a failing case, it **shrinks** it to the minimal reproducer. Capture that minimal case as a separate regression `@Example` (jqwik's equivalent of `@Test`) so it remains in the suite permanently.
+- Property tests complement but do not replace example-based tests. Use example tests for known edge cases and documented requirements; use property tests for invariants and exploratory coverage.
+
+### Testing Pyramid - Recommended Ratios
+
+| Layer | Scope | Speed | Volume |
+|---|---|---|---|
+| **Property tests** | Invariants across generated inputs | Fast | High (per property, thousands of cases) |
+| **Unit tests** | Single class/method, positive + negative | Fast | High (bulk of test count) |
+| **Integration tests** | Cross-component, external systems | Medium | Moderate |
+| **End-to-end tests** | Full system behavior | Slow | Few, focused on critical paths |
+
+### Integration Tests
+
+- Place integration tests in `src/integrationTest/java` with a separate source set.
+- Integration tests may touch external systems (databases, HTTP services, filesystems). They run after unit tests (`shouldRunAfter(tasks.named('test'))`).
+- Ask: *does this code need integration tests?* Code that interacts with external systems or configuration often can't be adequately tested with unit tests alone.
+
+### General Testing Principles
+
+- Tests must not call each other or depend on execution order.
+- Separate **refactoring changes** from **behavior changes**-never in the same commit.
+- Run the full test suite locally and verify CI passes *before* requesting review.
+- **Test behavior, not implementation.** Tests that assert on internal method calls, field values, or mock interaction counts are brittle. Test the observable output.
+- When a bug is found, **write a failing test first**, then fix the code. The test is the proof the bug existed and won't return.
+
+---
+
+## 11. Code Reviews
+
+### Author Responsibilities
+- Changes should have a **narrow, well-defined, self-contained scope**.
+- If a CR touches more than ~5 files, took longer than 1–2 days to write, or would take more than 20 minutes to review, **split it**.
+- Submit only complete, self-reviewed (by diff), and self-tested CRs.
+- Separate refactoring from behavior changes. Refactoring CRs must not alter behavior; behavior-changing CRs must not include formatting/refactoring.
+- For complex features, use a **stacked CR model**: a primary feature branch with secondary sub-branches, each individually reviewed.
+
+### Reviewer Responsibilities
+- Focus on program logic, not style (automated tooling handles style).
+- Verify: correctness, edge cases, error handling, test coverage (positive *and* negative), API design, documentation updates.
+- Check: are there property-based tests for code with clear invariants (serialization, codecs, data structure operations)?
+- Ask: *does this code need integration tests?*
+- Check: was external documentation (README, CHANGELOG) updated?
+- Verify: does each new/modified class have a single, clear responsibility?
+- **Praise** concise, readable, efficient, and elegant code.
+
+---
+
+## 12. Build & Toolchain
+
+- Apply `com.palantir.baseline` to the root project. Individual plugins auto-apply to subprojects.
+- Use `com.palantir.consistent-versions` for dependency locking. Lock files must be committed.
+- Use `com.palantir.baseline-java-versions` to configure compiler, library target, and distribution target versions.
+- Enable Error Prone checks. Treat warnings as errors in CI: `options.compilerArgs += ['-Werror']`.
+- Enforce classpath uniqueness via `baseline-class-uniqueness` to prevent duplicate class definitions.
+- Use UTF-8 encoding for all compilation tasks.
+- Default test heap: 2GB. Default compile heap: 2GB.
+- Enable the `-parameters` compiler flag for reflection metadata.
+- Use Gradle's `--parallel` mode and incremental compilation.
+
+---
+
+## 13. Dependency Hygiene
+
+- Run `./gradlew why --dependency <dep>` to understand why a version was chosen.
+- Run `./gradlew checkClassUniqueness` to detect conflicting JARs on the classpath.
+- Prefer project modules over external modules (`baseline-prefer-project-modules`).
+- Pin dependency versions in `versions.props`; verify with `versions.lock`.
+- Never resolve dependencies at Gradle configuration time.
+
+---
+
+## 14. Performance-Critical Code
+
+- Profile before optimizing. Use JMH for microbenchmarks (`src/jmh/java`).
+- Avoid parallel streams (see §5). Use explicit `ExecutorService` for parallelism.
+- Prefer primitive arrays and specialized collections (e.g., Eclipse Collections, `int[]`) over boxed collections on hot paths.
+- Minimize allocation in tight loops. Reuse buffers where safe.
+- Be aware of JIT compilation behavior: small, focused methods inline better.
+- Avoid unnecessary autoboxing on critical paths.
+
+---
+
+## 15. Safety & Correctness Checklist
+
+Use this as a pre-commit/pre-review mental checklist:
+
+| Area | Question |
+|---|---|
+| **SRP** | Does each class have exactly one reason to change? |
+| **Immutability** | Are all fields final? Are returned collections unmodifiable? |
+| **Nullability** | Are `@Nullable` / `@NonNull` annotations present? Is `Optional` used correctly? |
+| **Concurrency** | Is shared mutable state properly synchronized? Are there race conditions? |
+| **Error handling** | Are exceptions handled consistently? Are error logs actionable? |
+| **Logging** | Are log arguments safe-logged? Are messages constant strings? |
+| **Positive tests** | Is the happy path covered for every public method? |
+| **Negative tests** | Are null inputs, boundaries, malformed data, and failures tested? |
+| **Property tests** | Do serialization, codecs, or invariant-rich code have jqwik properties? |
+| **Dependencies** | Are new dependencies justified? Do they introduce classpath conflicts? |
+| **API surface** | Is the new API minimal, consistent, and hard to misuse? |
+| **Build** | Does `./gradlew check` pass? Are lock files updated? |
+
+---
+
+## 16. Anti-Patterns - Do Not
+
+| Anti-Pattern | Do Instead |
+|---|---|
+| God class (multiple responsibilities) | Split into focused, single-responsibility classes |
+| `Lists.newArrayList()` | `new ArrayList<>()` |
+| `Maps.newHashMap()` | `new HashMap<>()` |
+| `com.google.common.base.Optional` | `java.util.Optional` |
+| Raw `Thread` / `synchronized` | `ExecutorService` / `java.util.concurrent` |
+| `Collection.parallelStream()` | Explicit parallelism via `ExecutorService` |
+| Mutable static fields | Dependency injection or immutable constants |
+| `initialize()` post-construction | Factory pattern or Builder pattern |
+| Nested `try/catch` | Extract to separate methods |
+| String concatenation in log calls | SLF4J `{}` placeholders + SafeArg/UnsafeArg |
+| `new Boolean(true)` | `Boolean.TRUE` / `Boolean.valueOf(true)` |
+| Log4j / JUL / Logback direct | SLF4J |
+| Apache Commons Lang 2.x | Apache Commons Lang 3.x |
+| Style debates in code review | `./gradlew format` |
+| Only happy-path tests | Positive *and* negative test cases for every behavior |
+| Only example-based tests for invariants | Add jqwik `@Property` tests for round-trips and invariants |
+| Package-by-layer (`model`, `service`, `repo`) | Package-by-feature/domain |
+| Field injection (`@Inject` on fields) | Constructor injection |
+| Fat interfaces | Small, focused interfaces (Interface Segregation) |
+
+---
+
+## References
+
+- [Palantir Baseline Best Practices](https://github.com/palantir/gradle-baseline/tree/develop/docs/best-practices)
+- [Palantir Java Style Guide](https://github.com/palantir/gradle-baseline/tree/develop/docs/java-style-guide)
+- [Palantir Java Format](https://github.com/palantir/palantir-java-format)
+- [jqwik User Guide](https://jqwik.net/docs/current/user-guide.html)
+- *Effective Java, 3rd Edition* - Joshua Bloch
+- *Java Concurrency in Practice* - Brian Goetz et al.
+- *Clean Architecture* - Robert C. Martin (SRP, DIP, ISP)
+- [Google Error Prone](https://errorprone.info/)
+

--- a/jvm-diagnostics/build.gradle
+++ b/jvm-diagnostics/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'
+    testImplementation 'net.jqwik:jqwik'
 }
 
 moduleJvmArgs {

--- a/jvm-diagnostics/build.gradle
+++ b/jvm-diagnostics/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.jspecify:jspecify'
 
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/CpuPressure.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/CpuPressure.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.jvm.diagnostics;
+
+import java.util.OptionalDouble;
+
+/**
+ * CPU pressure metrics from Linux Pressure Stall Information (PSI).
+ * <p>
+ * These metrics track the percentage of time that at least one task was stalled
+ * waiting for CPU resources. CPU pressure only has "some" metrics (no "full" metrics)
+ * because the CPU is always running something.
+ */
+public interface CpuPressure {
+
+    /**
+     * Percentage of time at least one task was stalled on CPU over a 10-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg10();
+
+    /**
+     * Percentage of time at least one task was stalled on CPU over a 60-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg60();
+
+    /**
+     * Percentage of time at least one task was stalled on CPU over a 300-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg300();
+
+    /**
+     * Cumulative microseconds at least one task was stalled on CPU.
+     *
+     * @return total microseconds, or empty if unavailable
+     */
+    OptionalDouble someTotal();
+}

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/IoPressure.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/IoPressure.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.jvm.diagnostics;
+
+import java.util.OptionalDouble;
+
+/**
+ * I/O pressure metrics from Linux Pressure Stall Information (PSI).
+ * <p>
+ * These metrics track the time tasks spend waiting for I/O operations to complete.
+ * I/O pressure includes both "some" (at least one task stalled) and "full" (all
+ * non-idle tasks stalled) metrics.
+ */
+public interface IoPressure {
+
+    /**
+     * Percentage of time at least one task was stalled on I/O over a 10-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg10();
+
+    /**
+     * Percentage of time at least one task was stalled on I/O over a 60-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg60();
+
+    /**
+     * Percentage of time at least one task was stalled on I/O over a 300-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg300();
+
+    /**
+     * Cumulative microseconds at least one task was stalled on I/O.
+     *
+     * @return total microseconds, or empty if unavailable
+     */
+    OptionalDouble someTotal();
+
+    /**
+     * Percentage of time all non-idle tasks were stalled on I/O over a 10-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble fullAvg10();
+
+    /**
+     * Percentage of time all non-idle tasks were stalled on I/O over a 60-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble fullAvg60();
+
+    /**
+     * Percentage of time all non-idle tasks were stalled on I/O over a 300-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble fullAvg300();
+
+    /**
+     * Cumulative microseconds all non-idle tasks were stalled on I/O.
+     *
+     * @return total microseconds, or empty if unavailable
+     */
+    OptionalDouble fullTotal();
+}

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/JvmDiagnostics.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/JvmDiagnostics.java
@@ -19,15 +19,25 @@ package com.palantir.jvm.diagnostics;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.management.ManagementFactory;
 import java.lang.management.PlatformManagedObject;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.function.IntSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This utility class provides accessors to individual diagnostic getters. Every method should
@@ -161,6 +171,28 @@ public final class JvmDiagnostics {
             return accessor.isEnabled() ? Optional.of(accessor) : Optional.empty();
         } catch (Throwable t) {
             log.debug("Failed to create a HotspotVirtualThreadSchedulerAccessor", t);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns a {@link PressureMetricsAccessor} which provides access to Linux Pressure Stall Information (PSI)
+     * metrics. This functionality is only available on Linux systems with PSI support (kernel 4.20+).
+     *
+     * The accessor automatically detects container environments and prefers container-specific metrics when
+     * available, falling back to system-wide metrics otherwise.
+     *
+     * The resulting instance should be reused rather than calling this factory each time a value is needed.
+     *
+     * @return a PSI metrics accessor, or empty if PSI is not available
+     * @see <a href="https://docs.kernel.org/accounting/psi.html">Linux PSI Documentation</a>
+     */
+    public static Optional<PressureMetricsAccessor> pressureMetrics() {
+        try {
+            LinuxPressureMetricsAccessor accessor = new LinuxPressureMetricsAccessor();
+            return accessor.isEnabled() ? Optional.of(accessor) : Optional.empty();
+        } catch (Throwable t) {
+            log.debug("Failed to create a LinuxPressureMetricsAccessor", t);
             return Optional.empty();
         }
     }
@@ -392,6 +424,260 @@ public final class JvmDiagnostics {
             } catch (Throwable t) {
                 throw new SafeRuntimeException("failed to invoke VirtualThreadSchedulerMXBean#setParallelism", t);
             }
+        }
+    }
+
+    private static final class LinuxPressureMetricsAccessor implements PressureMetricsAccessor {
+        private static final Pattern CGROUP_V2_PATTERN = Pattern.compile("0::(.+)");
+        private static final Path PROC_SELF_CGROUP = Paths.get("/proc/self/cgroup");
+        private static final Path PROC_PRESSURE_CPU = Paths.get("/proc/pressure/cpu");
+        private static final Path PROC_PRESSURE_MEMORY = Paths.get("/proc/pressure/memory");
+        private static final Path PROC_PRESSURE_IO = Paths.get("/proc/pressure/io");
+
+        private final Path cpuPressurePath;
+        private final Path memoryPressurePath;
+        private final Path ioPressurePath;
+
+        LinuxPressureMetricsAccessor() {
+            String cgroupPath = detectCgroupPath();
+            if (cgroupPath != null) {
+                Path cgroupBase = Paths.get("/sys/fs/cgroup", cgroupPath);
+                cpuPressurePath = tryPath(cgroupBase.resolve("cpu.pressure"), PROC_PRESSURE_CPU);
+                memoryPressurePath = tryPath(cgroupBase.resolve("memory.pressure"), PROC_PRESSURE_MEMORY);
+                ioPressurePath = tryPath(cgroupBase.resolve("io.pressure"), PROC_PRESSURE_IO);
+                log.debug(
+                        "Using container-specific PSI paths",
+                        com.palantir.logsafe.SafeArg.of("cgroupPath", cgroupPath));
+            } else {
+                cpuPressurePath = PROC_PRESSURE_CPU;
+                memoryPressurePath = PROC_PRESSURE_MEMORY;
+                ioPressurePath = PROC_PRESSURE_IO;
+                log.debug("Using system-wide PSI paths");
+            }
+        }
+
+        boolean isEnabled() {
+            return Files.isReadable(cpuPressurePath)
+                    || Files.isReadable(memoryPressurePath)
+                    || Files.isReadable(ioPressurePath);
+        }
+
+        @Override
+        public Optional<CpuPressure> getCpuPressure() {
+            return Files.isReadable(cpuPressurePath)
+                    ? Optional.of(new PsiCpuPressure(cpuPressurePath))
+                    : Optional.empty();
+        }
+
+        @Override
+        public Optional<MemoryPressure> getMemoryPressure() {
+            return Files.isReadable(memoryPressurePath)
+                    ? Optional.of(new PsiMemoryPressure(memoryPressurePath))
+                    : Optional.empty();
+        }
+
+        @Override
+        public Optional<IoPressure> getIoPressure() {
+            return Files.isReadable(ioPressurePath) ? Optional.of(new PsiIoPressure(ioPressurePath)) : Optional.empty();
+        }
+
+        private static String detectCgroupPath() {
+            if (!Files.isReadable(PROC_SELF_CGROUP)) {
+                return null;
+            }
+
+            try (BufferedReader reader = Files.newBufferedReader(PROC_SELF_CGROUP)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    Matcher matcher = CGROUP_V2_PATTERN.matcher(line);
+                    if (matcher.matches()) {
+                        return matcher.group(1);
+                    }
+                }
+            } catch (IOException e) {
+                log.debug("Failed to read cgroup info", e);
+            }
+            return null;
+        }
+
+        private static Path tryPath(Path containerPath, Path systemPath) {
+            return Files.isReadable(containerPath) ? containerPath : systemPath;
+        }
+    }
+
+    private static final class PsiCpuPressure implements CpuPressure {
+        private final Path path;
+
+        PsiCpuPressure(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public OptionalDouble someAvg10() {
+            return readMetric("some", "avg10");
+        }
+
+        @Override
+        public OptionalDouble someAvg60() {
+            return readMetric("some", "avg60");
+        }
+
+        @Override
+        public OptionalDouble someAvg300() {
+            return readMetric("some", "avg300");
+        }
+
+        @Override
+        public OptionalDouble someTotal() {
+            return readMetric("some", "total");
+        }
+
+        private OptionalDouble readMetric(String linePrefix, String metricName) {
+            Map<String, String> metrics = parsePsiFile(path, linePrefix);
+            return parseDouble(metrics.get(metricName));
+        }
+    }
+
+    private static final class PsiMemoryPressure implements MemoryPressure {
+        private final Path path;
+
+        PsiMemoryPressure(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public OptionalDouble someAvg10() {
+            return readMetric("some", "avg10");
+        }
+
+        @Override
+        public OptionalDouble someAvg60() {
+            return readMetric("some", "avg60");
+        }
+
+        @Override
+        public OptionalDouble someAvg300() {
+            return readMetric("some", "avg300");
+        }
+
+        @Override
+        public OptionalDouble someTotal() {
+            return readMetric("some", "total");
+        }
+
+        @Override
+        public OptionalDouble fullAvg10() {
+            return readMetric("full", "avg10");
+        }
+
+        @Override
+        public OptionalDouble fullAvg60() {
+            return readMetric("full", "avg60");
+        }
+
+        @Override
+        public OptionalDouble fullAvg300() {
+            return readMetric("full", "avg300");
+        }
+
+        @Override
+        public OptionalDouble fullTotal() {
+            return readMetric("full", "total");
+        }
+
+        private OptionalDouble readMetric(String linePrefix, String metricName) {
+            Map<String, String> metrics = parsePsiFile(path, linePrefix);
+            return parseDouble(metrics.get(metricName));
+        }
+    }
+
+    private static final class PsiIoPressure implements IoPressure {
+        private final Path path;
+
+        PsiIoPressure(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public OptionalDouble someAvg10() {
+            return readMetric("some", "avg10");
+        }
+
+        @Override
+        public OptionalDouble someAvg60() {
+            return readMetric("some", "avg60");
+        }
+
+        @Override
+        public OptionalDouble someAvg300() {
+            return readMetric("some", "avg300");
+        }
+
+        @Override
+        public OptionalDouble someTotal() {
+            return readMetric("some", "total");
+        }
+
+        @Override
+        public OptionalDouble fullAvg10() {
+            return readMetric("full", "avg10");
+        }
+
+        @Override
+        public OptionalDouble fullAvg60() {
+            return readMetric("full", "avg60");
+        }
+
+        @Override
+        public OptionalDouble fullAvg300() {
+            return readMetric("full", "avg300");
+        }
+
+        @Override
+        public OptionalDouble fullTotal() {
+            return readMetric("full", "total");
+        }
+
+        private OptionalDouble readMetric(String linePrefix, String metricName) {
+            Map<String, String> metrics = parsePsiFile(path, linePrefix);
+            return parseDouble(metrics.get(metricName));
+        }
+    }
+
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+    private static final Pattern EQUALS_PATTERN = Pattern.compile("=");
+
+    @SuppressWarnings("StringSplitter") // Pattern.split is appropriate here; Guava is not a dependency
+    private static Map<String, String> parsePsiFile(Path path, String linePrefix) {
+        Map<String, String> metrics = new HashMap<>();
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(linePrefix)) {
+                    String[] parts = WHITESPACE_PATTERN.split(line);
+                    for (int i = 1; i < parts.length; i++) {
+                        String[] keyValue = EQUALS_PATTERN.split(parts[i], 2);
+                        if (keyValue.length == 2) {
+                            metrics.put(keyValue[0], keyValue[1]);
+                        }
+                    }
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            log.debug("Failed to read PSI file", com.palantir.logsafe.SafeArg.of("path", path), e);
+        }
+        return metrics;
+    }
+
+    private static OptionalDouble parseDouble(String value) {
+        if (value == null) {
+            return OptionalDouble.empty();
+        }
+        try {
+            return OptionalDouble.of(Double.parseDouble(value));
+        } catch (NumberFormatException e) {
+            return OptionalDouble.empty();
         }
     }
 }

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/JvmDiagnostics.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/JvmDiagnostics.java
@@ -16,6 +16,7 @@
 
 package com.palantir.jvm.diagnostics;
 
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -35,9 +36,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
+import java.util.function.BiConsumer;
 import java.util.function.IntSupplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This utility class provides accessors to individual diagnostic getters. Every method should
@@ -442,16 +445,14 @@ public final class JvmDiagnostics {
             String cgroupPath = detectCgroupPath();
             if (cgroupPath != null) {
                 Path cgroupBase = Paths.get("/sys/fs/cgroup", cgroupPath);
-                cpuPressurePath = tryPath(cgroupBase.resolve("cpu.pressure"), PROC_PRESSURE_CPU);
-                memoryPressurePath = tryPath(cgroupBase.resolve("memory.pressure"), PROC_PRESSURE_MEMORY);
-                ioPressurePath = tryPath(cgroupBase.resolve("io.pressure"), PROC_PRESSURE_IO);
-                log.debug(
-                        "Using container-specific PSI paths",
-                        com.palantir.logsafe.SafeArg.of("cgroupPath", cgroupPath));
+                this.cpuPressurePath = tryPath(cgroupBase.resolve("cpu.pressure"), PROC_PRESSURE_CPU);
+                this.memoryPressurePath = tryPath(cgroupBase.resolve("memory.pressure"), PROC_PRESSURE_MEMORY);
+                this.ioPressurePath = tryPath(cgroupBase.resolve("io.pressure"), PROC_PRESSURE_IO);
+                log.debug("Using container-specific PSI paths", SafeArg.of("cgroupPath", cgroupPath));
             } else {
-                cpuPressurePath = PROC_PRESSURE_CPU;
-                memoryPressurePath = PROC_PRESSURE_MEMORY;
-                ioPressurePath = PROC_PRESSURE_IO;
+                this.cpuPressurePath = PROC_PRESSURE_CPU;
+                this.memoryPressurePath = PROC_PRESSURE_MEMORY;
+                this.ioPressurePath = PROC_PRESSURE_IO;
                 log.debug("Using system-wide PSI paths");
             }
         }
@@ -481,6 +482,7 @@ public final class JvmDiagnostics {
             return Files.isReadable(ioPressurePath) ? Optional.of(new PsiIoPressure(ioPressurePath)) : Optional.empty();
         }
 
+        @Nullable
         private static String detectCgroupPath() {
             if (!Files.isReadable(PROC_SELF_CGROUP)) {
                 return null;
@@ -650,27 +652,32 @@ public final class JvmDiagnostics {
     @SuppressWarnings("StringSplitter") // Pattern.split is appropriate here; Guava is not a dependency
     private static Map<String, String> parsePsiFile(Path path, String linePrefix) {
         Map<String, String> metrics = new HashMap<>();
+        BiConsumer<String, String> metricConsumer = metrics::put;
         try (BufferedReader reader = Files.newBufferedReader(path)) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (line.startsWith(linePrefix)) {
                     String[] parts = WHITESPACE_PATTERN.split(line);
                     for (int i = 1; i < parts.length; i++) {
-                        String[] keyValue = EQUALS_PATTERN.split(parts[i], 2);
-                        if (keyValue.length == 2) {
-                            metrics.put(keyValue[0], keyValue[1]);
-                        }
+                        parsePressureComponents(parts[i], metricConsumer);
                     }
                     break;
                 }
             }
         } catch (IOException e) {
-            log.debug("Failed to read PSI file", com.palantir.logsafe.SafeArg.of("path", path), e);
+            log.debug("Failed to read PSI file", SafeArg.of("path", path), e);
         }
         return metrics;
     }
 
-    private static OptionalDouble parseDouble(String value) {
+    static void parsePressureComponents(String input, BiConsumer<String, String> metricConsumer) {
+        String[] keyValue = EQUALS_PATTERN.split(input, 2);
+        if (keyValue.length == 2) {
+            metricConsumer.accept(keyValue[0], keyValue[1]);
+        }
+    }
+
+    static OptionalDouble parseDouble(String value) {
         if (value == null) {
             return OptionalDouble.empty();
         }

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/MemoryPressure.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/MemoryPressure.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.jvm.diagnostics;
+
+import java.util.OptionalDouble;
+
+/**
+ * Memory pressure metrics from Linux Pressure Stall Information (PSI).
+ * <p>
+ * These metrics track the time tasks spend waiting for memory resources or
+ * during memory reclamation. Memory pressure includes both "some" (at least one
+ * task stalled) and "full" (all non-idle tasks stalled) metrics.
+ */
+public interface MemoryPressure {
+
+    /**
+     * Percentage of time at least one task was stalled on memory over a 10-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg10();
+
+    /**
+     * Percentage of time at least one task was stalled on memory over a 60-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg60();
+
+    /**
+     * Percentage of time at least one task was stalled on memory over a 300-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble someAvg300();
+
+    /**
+     * Cumulative microseconds at least one task was stalled on memory.
+     *
+     * @return total microseconds, or empty if unavailable
+     */
+    OptionalDouble someTotal();
+
+    /**
+     * Percentage of time all non-idle tasks were stalled on memory over a 10-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble fullAvg10();
+
+    /**
+     * Percentage of time all non-idle tasks were stalled on memory over a 60-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble fullAvg60();
+
+    /**
+     * Percentage of time all non-idle tasks were stalled on memory over a 300-second window.
+     *
+     * @return percentage (0-100), or empty if unavailable
+     */
+    OptionalDouble fullAvg300();
+
+    /**
+     * Cumulative microseconds all non-idle tasks were stalled on memory.
+     *
+     * @return total microseconds, or empty if unavailable
+     */
+    OptionalDouble fullTotal();
+}

--- a/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/PressureMetricsAccessor.java
+++ b/jvm-diagnostics/src/main/java/com/palantir/jvm/diagnostics/PressureMetricsAccessor.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.jvm.diagnostics;
+
+import java.util.Optional;
+
+/**
+ * Provides access to Linux Pressure Stall Information (PSI) metrics.
+ * <p>
+ * PSI tracks the time that tasks spend waiting for CPU, memory, or I/O resources.
+ * This accessor automatically detects if running in a container environment and
+ * prefers container-specific metrics when available, falling back to system-wide
+ * metrics otherwise.
+ * <p>
+ * On non-Linux systems or when PSI is not available, the accessor methods return
+ * empty {@link Optional} values.
+ *
+ * @see <a href="https://docs.kernel.org/accounting/psi.html">Linux PSI Documentation</a>
+ */
+public interface PressureMetricsAccessor {
+
+    /**
+     * Returns CPU pressure metrics. Automatically detects container environment and
+     * returns container-specific metrics when available, otherwise system-wide metrics.
+     * <p>
+     * CPU pressure indicates time spent waiting for CPU resources.
+     *
+     * @return CPU pressure metrics, or empty if unavailable
+     */
+    Optional<CpuPressure> getCpuPressure();
+
+    /**
+     * Returns memory pressure metrics. Automatically detects container environment and
+     * returns container-specific metrics when available, otherwise system-wide metrics.
+     * <p>
+     * Memory pressure indicates time spent waiting for memory resources or reclaiming pages.
+     *
+     * @return memory pressure metrics, or empty if unavailable
+     */
+    Optional<MemoryPressure> getMemoryPressure();
+
+    /**
+     * Returns I/O pressure metrics. Automatically detects container environment and
+     * returns container-specific metrics when available, otherwise system-wide metrics.
+     * <p>
+     * I/O pressure indicates time spent waiting for I/O operations to complete.
+     *
+     * @return I/O pressure metrics, or empty if unavailable
+     */
+    Optional<IoPressure> getIoPressure();
+}

--- a/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsProperties.java
+++ b/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsProperties.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.jvm.diagnostics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.constraints.DoubleRange;
+
+/**
+ * Property-based tests for PSI metrics using jqwik.
+ * These tests verify invariants that should hold across all valid inputs.
+ */
+class PressureMetricsProperties {
+
+    @Property(tries = 100)
+    void avgPercentagesAlwaysInRange0To100(
+            @ForAll @DoubleRange(min = 0.0, max = 100.0) double avg10,
+            @ForAll @DoubleRange(min = 0.0, max = 100.0) double avg60,
+            @ForAll @DoubleRange(min = 0.0, max = 100.0) double avg300) {
+        // Verify that the percentages we generate are in valid range
+        assertThat(avg10).isBetween(0.0, 100.0);
+        assertThat(avg60).isBetween(0.0, 100.0);
+        assertThat(avg300).isBetween(0.0, 100.0);
+    }
+
+    @Property(tries = 100)
+    void totalMicrosecondsAlwaysNonNegative(@ForAll("validTotalMicroseconds") double total) {
+        // Verify that totals are always non-negative
+        assertThat(total).isGreaterThanOrEqualTo(0.0);
+    }
+
+    @Property(tries = 100)
+    @SuppressWarnings("StringSplitter") // Test code, validates parsing behavior
+    void psiFormatParsingNeverThrows(@ForAll("validPsiLine") String psiLine) {
+        // Verify that parsing PSI format never throws exceptions
+        // This tests the robustness of the parsing logic
+        try {
+            String[] parts = psiLine.split("\\s+");
+            for (String part : parts) {
+                if (part.contains("=")) {
+                    String[] keyValue = part.split("=", 2);
+                    if (keyValue.length == 2) {
+                        try {
+                            Double.parseDouble(keyValue[1]);
+                        } catch (NumberFormatException e) {
+                            // Expected for some generated inputs
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Parsing should never throw", e);
+        }
+    }
+
+    @Provide
+    Arbitrary<Double> validTotalMicroseconds() {
+        return Arbitraries.doubles().greaterOrEqual(0.0).lessOrEqual(Double.MAX_VALUE / 2);
+    }
+
+    @Provide
+    Arbitrary<String> validPsiLine() {
+        Arbitrary<Double> percentages = Arbitraries.doubles().between(0.0, 100.0);
+        Arbitrary<Long> totals = Arbitraries.longs().greaterOrEqual(0L);
+
+        return Arbitraries.randomValue(_random -> {
+            double avg10 = percentages.sample();
+            double avg60 = percentages.sample();
+            double avg300 = percentages.sample();
+            long total = totals.sample();
+
+            return String.format("some avg10=%.2f avg60=%.2f avg300=%.2f total=%d", avg10, avg60, avg300, total);
+        });
+    }
+}

--- a/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsPropertiesTest.java
+++ b/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsPropertiesTest.java
@@ -23,52 +23,27 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
-import net.jqwik.api.constraints.DoubleRange;
 
 /**
  * Property-based tests for PSI metrics using jqwik.
  * These tests verify invariants that should hold across all valid inputs.
  */
-class PressureMetricsProperties {
+class PressureMetricsPropertiesTest {
 
-    @Property(tries = 100)
-    void avgPercentagesAlwaysInRange0To100(
-            @ForAll @DoubleRange(min = 0.0, max = 100.0) double avg10,
-            @ForAll @DoubleRange(min = 0.0, max = 100.0) double avg60,
-            @ForAll @DoubleRange(min = 0.0, max = 100.0) double avg300) {
-        // Verify that the percentages we generate are in valid range
-        assertThat(avg10).isBetween(0.0, 100.0);
-        assertThat(avg60).isBetween(0.0, 100.0);
-        assertThat(avg300).isBetween(0.0, 100.0);
-    }
-
-    @Property(tries = 100)
-    void totalMicrosecondsAlwaysNonNegative(@ForAll("validTotalMicroseconds") double total) {
-        // Verify that totals are always non-negative
-        assertThat(total).isGreaterThanOrEqualTo(0.0);
-    }
-
-    @Property(tries = 100)
+    @Property(tries = 10000)
     @SuppressWarnings("StringSplitter") // Test code, validates parsing behavior
     void psiFormatParsingNeverThrows(@ForAll("validPsiLine") String psiLine) {
         // Verify that parsing PSI format never throws exceptions
         // This tests the robustness of the parsing logic
-        try {
-            String[] parts = psiLine.split("\\s+");
-            for (String part : parts) {
-                if (part.contains("=")) {
-                    String[] keyValue = part.split("=", 2);
-                    if (keyValue.length == 2) {
-                        try {
-                            Double.parseDouble(keyValue[1]);
-                        } catch (NumberFormatException e) {
-                            // Expected for some generated inputs
-                        }
-                    }
-                }
+        for (String part : psiLine.split("\\s+")) {
+            if (part.contains("=")) {
+                JvmDiagnostics.parsePressureComponents(part, (key, value) -> {
+                    assertThat(key).isNotNull().isNotEmpty().containsAnyOf("avg10", "avg60", "avg300", "total");
+                    assertThat(value).isNotNull().isNotEmpty().satisfies(v -> assertThat(Double.parseDouble(v))
+                            .isNotNaN());
+                    assertThat(JvmDiagnostics.parseDouble(value)).isNotNull().isNotEmpty();
+                });
             }
-        } catch (Exception e) {
-            throw new AssertionError("Parsing should never throw", e);
         }
     }
 

--- a/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsTest.java
+++ b/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsTest.java
@@ -60,7 +60,7 @@ class PressureMetricsTest {
             Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
             assumeThat(accessor).isPresent();
 
-            Optional<CpuPressure> cpuPressure = accessor.get().getCpuPressure();
+            Optional<CpuPressure> cpuPressure = accessor.orElseThrow().getCpuPressure();
 
             assertThat(cpuPressure)
                     .describedAs("CPU pressure should be available")
@@ -90,10 +90,10 @@ class PressureMetricsTest {
             Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
             assumeThat(accessor).isPresent();
 
-            Optional<CpuPressure> cpuPressure = accessor.get().getCpuPressure();
+            Optional<CpuPressure> cpuPressure = accessor.orElseThrow().getCpuPressure();
             assumeThat(cpuPressure).isPresent();
 
-            CpuPressure cpu = cpuPressure.get();
+            CpuPressure cpu = cpuPressure.orElseThrow();
 
             // Percentages should be 0-100
             cpu.someAvg10().ifPresent(value -> assertThat(value)
@@ -121,13 +121,13 @@ class PressureMetricsTest {
             Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
             assumeThat(accessor).isPresent();
 
-            Optional<MemoryPressure> memoryPressure = accessor.get().getMemoryPressure();
+            Optional<MemoryPressure> memoryPressure = accessor.orElseThrow().getMemoryPressure();
 
             assertThat(memoryPressure)
                     .describedAs("Memory pressure should be available")
                     .isPresent();
 
-            MemoryPressure memory = memoryPressure.get();
+            MemoryPressure memory = memoryPressure.orElseThrow();
             assertThat(memory.someAvg10())
                     .describedAs("Memory someAvg10 should be present")
                     .isPresent();
@@ -163,10 +163,10 @@ class PressureMetricsTest {
             Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
             assumeThat(accessor).isPresent();
 
-            Optional<MemoryPressure> memoryPressure = accessor.get().getMemoryPressure();
+            Optional<MemoryPressure> memoryPressure = accessor.orElseThrow().getMemoryPressure();
             assumeThat(memoryPressure).isPresent();
 
-            MemoryPressure memory = memoryPressure.get();
+            MemoryPressure memory = memoryPressure.orElseThrow();
 
             // Percentages should be 0-100
             memory.someAvg10().ifPresent(value -> assertThat(value)
@@ -206,13 +206,13 @@ class PressureMetricsTest {
             Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
             assumeThat(accessor).isPresent();
 
-            Optional<IoPressure> ioPressure = accessor.get().getIoPressure();
+            Optional<IoPressure> ioPressure = accessor.orElseThrow().getIoPressure();
 
             assertThat(ioPressure)
                     .describedAs("I/O pressure should be available")
                     .isPresent();
 
-            IoPressure io = ioPressure.get();
+            IoPressure io = ioPressure.orElseThrow();
             assertThat(io.someAvg10())
                     .describedAs("I/O someAvg10 should be present")
                     .isPresent();
@@ -248,10 +248,10 @@ class PressureMetricsTest {
             Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
             assumeThat(accessor).isPresent();
 
-            Optional<IoPressure> ioPressure = accessor.get().getIoPressure();
+            Optional<IoPressure> ioPressure = accessor.orElseThrow().getIoPressure();
             assumeThat(ioPressure).isPresent();
 
-            IoPressure io = ioPressure.get();
+            IoPressure io = ioPressure.orElseThrow();
 
             // Percentages should be 0-100
             io.someAvg10().ifPresent(value -> assertThat(value)
@@ -292,15 +292,15 @@ class PressureMetricsTest {
             assumeThat(accessor).isPresent();
 
             // Read metrics multiple times
-            Optional<CpuPressure> cpu1 = accessor.get().getCpuPressure();
-            Optional<CpuPressure> cpu2 = accessor.get().getCpuPressure();
+            Optional<CpuPressure> cpu1 = accessor.orElseThrow().getCpuPressure();
+            Optional<CpuPressure> cpu2 = accessor.orElseThrow().getCpuPressure();
 
             assertThat(cpu1).isPresent();
             assertThat(cpu2).isPresent();
 
             // Verify we can read values from both instances
-            OptionalDouble value1 = cpu1.get().someAvg10();
-            OptionalDouble value2 = cpu2.get().someAvg10();
+            OptionalDouble value1 = cpu1.orElseThrow().someAvg10();
+            OptionalDouble value2 = cpu2.orElseThrow().someAvg10();
 
             assertThat(value1).isPresent();
             assertThat(value2).isPresent();

--- a/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsTest.java
+++ b/jvm-diagnostics/src/test/java/com/palantir/jvm/diagnostics/PressureMetricsTest.java
@@ -1,0 +1,381 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.jvm.diagnostics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PressureMetricsTest {
+
+    private static final Path PROC_PRESSURE_CPU = Paths.get("/proc/pressure/cpu");
+    private static final Path PROC_PRESSURE_MEMORY = Paths.get("/proc/pressure/memory");
+    private static final Path PROC_PRESSURE_IO = Paths.get("/proc/pressure/io");
+
+    @Nested
+    class PositiveTests {
+
+        @Test
+        void pressureMetricsAccessorIsAvailableOnLinuxWithPsi() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_CPU)
+                            || Files.isReadable(PROC_PRESSURE_MEMORY)
+                            || Files.isReadable(PROC_PRESSURE_IO))
+                    .describedAs("PSI files should be readable on Linux with PSI support")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+
+            assertThat(accessor)
+                    .describedAs("Accessor should be present on Linux with PSI")
+                    .isPresent();
+        }
+
+        @Test
+        void cpuPressureMetricsAreAccessible() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_CPU))
+                    .describedAs("CPU pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            Optional<CpuPressure> cpuPressure = accessor.get().getCpuPressure();
+
+            assertThat(cpuPressure)
+                    .describedAs("CPU pressure should be available")
+                    .isPresent();
+
+            CpuPressure cpu = cpuPressure.get();
+            assertThat(cpu.someAvg10())
+                    .describedAs("CPU someAvg10 should be present")
+                    .isPresent();
+            assertThat(cpu.someAvg60())
+                    .describedAs("CPU someAvg60 should be present")
+                    .isPresent();
+            assertThat(cpu.someAvg300())
+                    .describedAs("CPU someAvg300 should be present")
+                    .isPresent();
+            assertThat(cpu.someTotal())
+                    .describedAs("CPU someTotal should be present")
+                    .isPresent();
+        }
+
+        @Test
+        void cpuPressureValuesAreReasonable() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_CPU))
+                    .describedAs("CPU pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            Optional<CpuPressure> cpuPressure = accessor.get().getCpuPressure();
+            assumeThat(cpuPressure).isPresent();
+
+            CpuPressure cpu = cpuPressure.get();
+
+            // Percentages should be 0-100
+            cpu.someAvg10().ifPresent(value -> assertThat(value)
+                    .describedAs("CPU someAvg10 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            cpu.someAvg60().ifPresent(value -> assertThat(value)
+                    .describedAs("CPU someAvg60 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            cpu.someAvg300().ifPresent(value -> assertThat(value)
+                    .describedAs("CPU someAvg300 should be 0-100")
+                    .isBetween(0.0, 100.0));
+
+            // Total microseconds should be non-negative
+            cpu.someTotal().ifPresent(value -> assertThat(value)
+                    .describedAs("CPU someTotal should be non-negative")
+                    .isGreaterThanOrEqualTo(0.0));
+        }
+
+        @Test
+        void memoryPressureMetricsAreAccessible() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_MEMORY))
+                    .describedAs("Memory pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            Optional<MemoryPressure> memoryPressure = accessor.get().getMemoryPressure();
+
+            assertThat(memoryPressure)
+                    .describedAs("Memory pressure should be available")
+                    .isPresent();
+
+            MemoryPressure memory = memoryPressure.get();
+            assertThat(memory.someAvg10())
+                    .describedAs("Memory someAvg10 should be present")
+                    .isPresent();
+            assertThat(memory.someAvg60())
+                    .describedAs("Memory someAvg60 should be present")
+                    .isPresent();
+            assertThat(memory.someAvg300())
+                    .describedAs("Memory someAvg300 should be present")
+                    .isPresent();
+            assertThat(memory.someTotal())
+                    .describedAs("Memory someTotal should be present")
+                    .isPresent();
+            assertThat(memory.fullAvg10())
+                    .describedAs("Memory fullAvg10 should be present")
+                    .isPresent();
+            assertThat(memory.fullAvg60())
+                    .describedAs("Memory fullAvg60 should be present")
+                    .isPresent();
+            assertThat(memory.fullAvg300())
+                    .describedAs("Memory fullAvg300 should be present")
+                    .isPresent();
+            assertThat(memory.fullTotal())
+                    .describedAs("Memory fullTotal should be present")
+                    .isPresent();
+        }
+
+        @Test
+        void memoryPressureValuesAreReasonable() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_MEMORY))
+                    .describedAs("Memory pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            Optional<MemoryPressure> memoryPressure = accessor.get().getMemoryPressure();
+            assumeThat(memoryPressure).isPresent();
+
+            MemoryPressure memory = memoryPressure.get();
+
+            // Percentages should be 0-100
+            memory.someAvg10().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory someAvg10 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            memory.someAvg60().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory someAvg60 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            memory.someAvg300().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory someAvg300 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            memory.fullAvg10().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory fullAvg10 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            memory.fullAvg60().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory fullAvg60 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            memory.fullAvg300().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory fullAvg300 should be 0-100")
+                    .isBetween(0.0, 100.0));
+
+            // Totals should be non-negative
+            memory.someTotal().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory someTotal should be non-negative")
+                    .isGreaterThanOrEqualTo(0.0));
+            memory.fullTotal().ifPresent(value -> assertThat(value)
+                    .describedAs("Memory fullTotal should be non-negative")
+                    .isGreaterThanOrEqualTo(0.0));
+        }
+
+        @Test
+        void ioPressureMetricsAreAccessible() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_IO))
+                    .describedAs("I/O pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            Optional<IoPressure> ioPressure = accessor.get().getIoPressure();
+
+            assertThat(ioPressure)
+                    .describedAs("I/O pressure should be available")
+                    .isPresent();
+
+            IoPressure io = ioPressure.get();
+            assertThat(io.someAvg10())
+                    .describedAs("I/O someAvg10 should be present")
+                    .isPresent();
+            assertThat(io.someAvg60())
+                    .describedAs("I/O someAvg60 should be present")
+                    .isPresent();
+            assertThat(io.someAvg300())
+                    .describedAs("I/O someAvg300 should be present")
+                    .isPresent();
+            assertThat(io.someTotal())
+                    .describedAs("I/O someTotal should be present")
+                    .isPresent();
+            assertThat(io.fullAvg10())
+                    .describedAs("I/O fullAvg10 should be present")
+                    .isPresent();
+            assertThat(io.fullAvg60())
+                    .describedAs("I/O fullAvg60 should be present")
+                    .isPresent();
+            assertThat(io.fullAvg300())
+                    .describedAs("I/O fullAvg300 should be present")
+                    .isPresent();
+            assertThat(io.fullTotal())
+                    .describedAs("I/O fullTotal should be present")
+                    .isPresent();
+        }
+
+        @Test
+        void ioPressureValuesAreReasonable() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_IO))
+                    .describedAs("I/O pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            Optional<IoPressure> ioPressure = accessor.get().getIoPressure();
+            assumeThat(ioPressure).isPresent();
+
+            IoPressure io = ioPressure.get();
+
+            // Percentages should be 0-100
+            io.someAvg10().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O someAvg10 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            io.someAvg60().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O someAvg60 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            io.someAvg300().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O someAvg300 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            io.fullAvg10().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O fullAvg10 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            io.fullAvg60().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O fullAvg60 should be 0-100")
+                    .isBetween(0.0, 100.0));
+            io.fullAvg300().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O fullAvg300 should be 0-100")
+                    .isBetween(0.0, 100.0));
+
+            // Totals should be non-negative
+            io.someTotal().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O someTotal should be non-negative")
+                    .isGreaterThanOrEqualTo(0.0));
+            io.fullTotal().ifPresent(value -> assertThat(value)
+                    .describedAs("I/O fullTotal should be non-negative")
+                    .isGreaterThanOrEqualTo(0.0));
+        }
+
+        @Test
+        void accessorCanBeReused() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_CPU))
+                    .describedAs("CPU pressure file should be readable")
+                    .isTrue();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+            assumeThat(accessor).isPresent();
+
+            // Read metrics multiple times
+            Optional<CpuPressure> cpu1 = accessor.get().getCpuPressure();
+            Optional<CpuPressure> cpu2 = accessor.get().getCpuPressure();
+
+            assertThat(cpu1).isPresent();
+            assertThat(cpu2).isPresent();
+
+            // Verify we can read values from both instances
+            OptionalDouble value1 = cpu1.get().someAvg10();
+            OptionalDouble value2 = cpu2.get().someAvg10();
+
+            assertThat(value1).isPresent();
+            assertThat(value2).isPresent();
+        }
+    }
+
+    @Nested
+    class NegativeTests {
+
+        @Test
+        void accessorReturnsEmptyOnNonLinuxPlatform() {
+            boolean anyPsiFileExists = Files.isReadable(PROC_PRESSURE_CPU)
+                    || Files.isReadable(PROC_PRESSURE_MEMORY)
+                    || Files.isReadable(PROC_PRESSURE_IO);
+
+            assumeThat(anyPsiFileExists)
+                    .describedAs("This test should only run when PSI files are not available")
+                    .isFalse();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+
+            assertThat(accessor)
+                    .describedAs("Accessor should be empty when PSI is not available")
+                    .isEmpty();
+        }
+
+        @Test
+        void cpuPressureReturnsEmptyWhenFileNotReadable() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_CPU))
+                    .describedAs("This test should only run when CPU pressure file is not readable")
+                    .isFalse();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+
+            // If accessor is present (other PSI files exist), CPU pressure should be empty
+            accessor.ifPresent(a -> {
+                Optional<CpuPressure> cpuPressure = a.getCpuPressure();
+                assertThat(cpuPressure)
+                        .describedAs("CPU pressure should be empty when file is not readable")
+                        .isEmpty();
+            });
+        }
+
+        @Test
+        void memoryPressureReturnsEmptyWhenFileNotReadable() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_MEMORY))
+                    .describedAs("This test should only run when memory pressure file is not readable")
+                    .isFalse();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+
+            // If accessor is present (other PSI files exist), memory pressure should be empty
+            accessor.ifPresent(a -> {
+                Optional<MemoryPressure> memoryPressure = a.getMemoryPressure();
+                assertThat(memoryPressure)
+                        .describedAs("Memory pressure should be empty when file is not readable")
+                        .isEmpty();
+            });
+        }
+
+        @Test
+        void ioPressureReturnsEmptyWhenFileNotReadable() {
+            assumeThat(Files.isReadable(PROC_PRESSURE_IO))
+                    .describedAs("This test should only run when I/O pressure file is not readable")
+                    .isFalse();
+
+            Optional<PressureMetricsAccessor> accessor = JvmDiagnostics.pressureMetrics();
+
+            // If accessor is present (other PSI files exist), I/O pressure should be empty
+            accessor.ifPresent(a -> {
+                Optional<IoPressure> ioPressure = a.getIoPressure();
+                assertThat(ioPressure)
+                        .describedAs("I/O pressure should be empty when file is not readable")
+                        .isEmpty();
+            });
+        }
+    }
+}

--- a/versions.lock
+++ b/versions.lock
@@ -14,6 +14,8 @@ com.palantir.safe-logging:safe-logging:3.11.0 (4 constraints: 3e3479fe)
 
 org.jetbrains:annotations:26.0.2 (1 constraints: 36116fd1)
 
+org.jspecify:jspecify:1.0.0 (6 constraints: 4166fe65)
+
 org.slf4j:slf4j-api:2.0.17 (1 constraints: 471091b6)
 
 
@@ -39,8 +41,6 @@ org.assertj:assertj-core:3.27.7 (1 constraints: 4505553b)
 org.awaitility:awaitility:4.3.0 (1 constraints: 09050836)
 
 org.hamcrest:hamcrest:2.1 (1 constraints: 6f0b2cce)
-
-org.jspecify:jspecify:1.0.0 (6 constraints: 4166fe65)
 
 org.junit.jupiter:junit-jupiter:6.0.2 (1 constraints: 49070b70)
 

--- a/versions.lock
+++ b/versions.lock
@@ -22,7 +22,17 @@ org.slf4j:slf4j-api:2.0.17 (1 constraints: 471091b6)
 
 net.bytebuddy:byte-buddy:1.18.3 (1 constraints: 530b55df)
 
-org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
+net.jqwik:jqwik:1.9.3 (1 constraints: 0f050e36)
+
+net.jqwik:jqwik-api:1.9.3 (4 constraints: 6724874c)
+
+net.jqwik:jqwik-engine:1.9.3 (1 constraints: a007006d)
+
+net.jqwik:jqwik-time:1.9.3 (1 constraints: a007006d)
+
+net.jqwik:jqwik-web:1.9.3 (1 constraints: a007006d)
+
+org.apiguardian:apiguardian-api:1.1.2 (11 constraints: 9293fa1e)
 
 org.assertj:assertj-core:3.27.7 (1 constraints: 4505553b)
 
@@ -40,10 +50,10 @@ org.junit.jupiter:junit-jupiter-engine:6.0.2 (1 constraints: 050ecc3b)
 
 org.junit.jupiter:junit-jupiter-params:6.0.2 (1 constraints: 050ecc3b)
 
-org.junit.platform:junit-platform-commons:6.0.2 (2 constraints: d7207a4a)
+org.junit.platform:junit-platform-commons:6.0.2 (4 constraints: 71346ef0)
 
-org.junit.platform:junit-platform-engine:6.0.2 (2 constraints: ef221108)
+org.junit.platform:junit-platform-engine:6.0.2 (3 constraints: 5a2d12c8)
 
 org.junit.platform:junit-platform-launcher:6.0.2 (1 constraints: 0a050b36)
 
-org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)
+org.opentest4j:opentest4j:1.3.0 (6 constraints: 7846fee1)

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,5 @@
 com.palantir.safe-logging:* = 3.11.0
+net.jqwik:* = 1.9.3
 org.junit.platform:* = 6.0.2
 org.slf4j:* = 2.0.17
 org.junit.jupiter:* = 6.0.2


### PR DESCRIPTION
## Before this PR

Linux pressure stall information metrics was not exposed via JVM diagnostics.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Implements access to CPU, memory, and I/O pressure metrics from the Linux
kernel's PSI subsystem. The implementation automatically detects container
environments and prefers container-specific metrics when available, with
graceful fallback to system-wide metrics.

New public interfaces:
- PressureMetricsAccessor: Factory method JvmDiagnostics.pressureMetrics()
- CpuPressure: CPU pressure metrics (someAvg10/60/300, someTotal)
- MemoryPressure: Memory pressure metrics (some + full variants)
- IoPressure: I/O pressure metrics (some + full variants)

Implementation features:
- Auto-detects cgroup v2 container paths
- Returns empty optionals when PSI unavailable
- Thread-safe, stateless reads
- Comprehensive test coverage with jqwik property-based tests

See https://docs.kernel.org/accounting/psi.html & https://facebookmicrosites.github.io/psi/docs/overview#pressure-metric-definitions

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

